### PR TITLE
Add `initDetails` override to report Android as the host system.

### DIFF
--- a/Android/lmst
+++ b/Android/lmst
@@ -66,6 +66,15 @@ package Slim::Utils::OS::Custom;
 use strict;
 use base qw(Slim::Utils::OS::Debian);
 
+sub initDetails {
+  my \$class = shift;
+
+  \$class->{osDetails} = \$class->SUPER::initDetails();
+  \$class->{osDetails}->{osName} .= " (Android)";
+
+  return \$class->{osDetails};
+}
+
 # Allow server to run as root in Termux Debian proot
 sub dontSetUserAndGroup { 1 }
 


### PR DESCRIPTION
Please note that I haven't tested this, lack of an Android device. But this addition should add the "Android" identifier to the OS name, which will allow to identify such installations.

Maybe this is helpful.